### PR TITLE
Equipment Page Sections

### DIFF
--- a/content/equipment/3D-printer.md
+++ b/content/equipment/3D-printer.md
@@ -2,6 +2,7 @@
 title: "3D Printer"
 date: 2018-09-26T09:00:13-07:00
 draft: false
+tags: ["other"]
 
 photo: flashforge-printer-700x700.jpg
 ---

--- a/content/equipment/band-saw.md
+++ b/content/equipment/band-saw.md
@@ -2,6 +2,7 @@
 title: "Band Saw"
 date: 2018-09-11T15:36:50-07:00
 draft: false
+tags: ["woodworking"]
 
 aliases:
     - /band_saw.html

--- a/content/equipment/belt-and-disc-sander.md
+++ b/content/equipment/belt-and-disc-sander.md
@@ -2,6 +2,7 @@
 title: "Belt and Disc Sander"
 date: 2018-09-11T16:22:11-07:00
 draft: false
+tags: ["woodworking"]
 
 aliases:
     - /belt-disc_sander.html

--- a/content/equipment/bench-grinder.md
+++ b/content/equipment/bench-grinder.md
@@ -2,6 +2,7 @@
 title: "Bench Grinder"
 date: 2018-09-11T19:35:49-07:00
 draft: false
+tags: ["metalworking"]
 
 aliases:
     - /bench_grinder.html

--- a/content/equipment/cabinet-saw.md
+++ b/content/equipment/cabinet-saw.md
@@ -2,6 +2,7 @@
 title: "Cabinet Saw"
 date: 2018-09-11T19:13:25-07:00
 draft: false
+tags: ["woodworking"]
 
 aliases:
     - /cabinet_saw.html

--- a/content/equipment/cnc-router.md
+++ b/content/equipment/cnc-router.md
@@ -2,6 +2,7 @@
 title: "CNC Router"
 date: 2018-09-18T16:14:47-07:00
 draft: false
+tags: ["woodworking", "metalworking"]
 
 aliases:
     - /cncrouter.html

--- a/content/equipment/cold-saw.md
+++ b/content/equipment/cold-saw.md
@@ -2,6 +2,7 @@
 title: "Cold Saw"
 date: 2018-09-11T16:55:09-07:00
 draft: false
+tags: ["metalworking"]
 
 aliases:
     - /cold_saw.html

--- a/content/equipment/drill-press.md
+++ b/content/equipment/drill-press.md
@@ -2,6 +2,7 @@
 title: "Drill Press"
 date: 2018-09-12T11:01:06-07:00
 draft: false
+tags: ["woodworking", "metalworking"]
 
 aliases:
     - /drill_press.html

--- a/content/equipment/laser-cutter.md
+++ b/content/equipment/laser-cutter.md
@@ -2,6 +2,7 @@
 title: "Laser Cutter"
 date: 2018-09-18T15:33:11-07:00
 draft: false
+tags: ["woodworking"] 
 
 aliases:
     - /laser.html

--- a/content/equipment/mig-welder.md
+++ b/content/equipment/mig-welder.md
@@ -2,6 +2,7 @@
 title: "MIG Welder"
 date: 2018-09-12T11:09:17-07:00
 draft: false
+tags: ["metalworking"]
 
 aliases:
     - /mig_welder.html

--- a/content/equipment/mill-and-lathe-combo.md
+++ b/content/equipment/mill-and-lathe-combo.md
@@ -2,6 +2,7 @@
 title: "Mill and Lathe Combo"
 date: 2018-09-12T16:20:32-07:00
 draft: false
+tags: ["metalworking"]
 
 aliases:
     - /mill-lathe_combo.html

--- a/content/equipment/miter-saw.md
+++ b/content/equipment/miter-saw.md
@@ -2,6 +2,7 @@
 title: "Miter Saw"
 date: 2018-09-11T17:14:09-07:00
 draft: false
+tags: ["woodworking"]
 
 aliases:
     - /miter_saw.html

--- a/content/equipment/panel-saw.md
+++ b/content/equipment/panel-saw.md
@@ -2,6 +2,7 @@
 title: "Panel Saw"
 date: 2018-09-18T17:14:16-07:00
 draft: false
+tags: ["woodworking"]
 
 aliases:
     - /panel_saw.html

--- a/content/equipment/plasma-cutter.md
+++ b/content/equipment/plasma-cutter.md
@@ -2,6 +2,7 @@
 title: "Plasma Cutter"
 date: 2018-09-18T15:04:49-07:00
 draft: false
+tags: ["metalworking"]
 
 aliases:
     - /plasma_cutter.html

--- a/content/equipment/router-table.md
+++ b/content/equipment/router-table.md
@@ -2,6 +2,7 @@
 title: "Router Table"
 date: 2018-09-18T16:48:55-07:00
 draft: false
+tags: ["woodworking"]
 
 aliases:
     - /router_table.html

--- a/content/equipment/scroll-saw.md
+++ b/content/equipment/scroll-saw.md
@@ -2,6 +2,7 @@
 title: "Scroll Saw"
 date: 2018-09-18T16:13:49-07:00
 draft: false
+tags: ["woodworking"]
 
 aliases:
     - /scroll_saw.html

--- a/content/equipment/sewing-machine.md
+++ b/content/equipment/sewing-machine.md
@@ -2,6 +2,7 @@
 title: "Sewing Machine"
 date: 2018-09-12T16:39:52-07:00
 draft: false
+tags: ["other"]
 
 aliases:
     - /sewing_machine.html

--- a/content/equipment/spindle-sander.md
+++ b/content/equipment/spindle-sander.md
@@ -2,6 +2,7 @@
 title: "Spindle Sander"
 date: 2018-09-11T16:36:22-07:00
 draft: false
+tags: ["woodworking"]
 
 aliases:
     - /spindle_sander.html

--- a/content/equipment/wood-lathe.md
+++ b/content/equipment/wood-lathe.md
@@ -2,6 +2,7 @@
 title: "Wood Lathe"
 date: 2018-09-11T16:56:21-07:00
 draft: false
+tags: ["woodworking"]
 
 aliases:
     - /wood_lathe.html

--- a/layouts/equipment/section.html
+++ b/layouts/equipment/section.html
@@ -1,9 +1,13 @@
 {{ define "main" }}
 <h1> {{ .Title }} </h1>
 
+<hr>
+
+<h2 class="text-center">Woodworking</h2>
+
 <section class="row mt-4">
 
-  {{ range .Pages }}
+  {{ range .Site.Taxonomies.tags.woodworking }}
   <div class="col-lg-4 col-md-6 mb-3 d-flex align-items-stretch">
     <div class="card">
       <a href="{{ .URL }}">
@@ -25,6 +29,62 @@
   </div>
 
   {{ end }}
+
+</section>
+
+<h2 class="text-center">Metalworking</h2>
+
+<section class="row mt-4">
+  {{ range .Site.Taxonomies.tags.metalworking }}
+  <div class="col-lg-4 col-md-6 mb-3 d-flex align-items-stretch">
+    <div class="card">
+      <a href="{{ .URL }}">
+        <img class="card-img-top" src="/equipment/{{ .Params.photo }}" alt="Card image cap">
+      </a>
+      <div class="card-body d-flex align-items-end">
+        <div class="col">
+          <div class="row">
+            <a href="{{ .URL }}">
+              <h5 class="card-title">{{ .Title }}</h5>
+            </a>
+          </div>
+          <div class="row">
+            <a href="{{ .URL }}" class="btn btn-primary">View Instructions</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {{ end }} 
+
+</section>
+
+<h2 class="text-center">Other</h2>
+
+<section class="row mt-4">
+  {{ range .Site.Taxonomies.tags.other }}
+  <div class="col-lg-4 col-md-6 mb-3 d-flex align-items-stretch">
+    <div class="card">
+      <a href="{{ .URL }}">
+        <img class="card-img-top" src="/equipment/{{ .Params.photo }}" alt="Card image cap">
+      </a>
+      <div class="card-body d-flex align-items-end">
+        <div class="col">
+          <div class="row">
+            <a href="{{ .URL }}">
+              <h5 class="card-title">{{ .Title }}</h5>
+            </a>
+          </div>
+          <div class="row">
+            <a href="{{ .URL }}" class="btn btn-primary">View Instructions</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {{ end }} 
 
 </section>
 

--- a/layouts/equipment/section.html
+++ b/layouts/equipment/section.html
@@ -1,14 +1,12 @@
 {{ define "main" }}
 <h1> {{ .Title }} </h1>
 
-<hr>
-
-<h2 class="text-center">Woodworking</h2>
+<h2 class="mt-4">Woodworking</h2>
 
 <section class="row mt-4">
 
   {{ range .Site.Taxonomies.tags.woodworking }}
-  <div class="col-lg-4 col-md-6 mb-3 d-flex align-items-stretch">
+  <div class="col-lg-3 col-md-6 my-3 d-flex align-items-stretch">
     <div class="card">
       <a href="{{ .URL }}">
         <img class="card-img-top" src="/equipment/{{ .Params.photo }}" alt="Card image cap">
@@ -32,11 +30,11 @@
 
 </section>
 
-<h2 class="text-center">Metalworking</h2>
+<h2 class="mt-4">Metalworking</h2>
 
 <section class="row mt-4">
   {{ range .Site.Taxonomies.tags.metalworking }}
-  <div class="col-lg-4 col-md-6 mb-3 d-flex align-items-stretch">
+  <div class="col-lg-3 col-md-6 my-3 d-flex align-items-stretch">
     <div class="card">
       <a href="{{ .URL }}">
         <img class="card-img-top" src="/equipment/{{ .Params.photo }}" alt="Card image cap">
@@ -60,11 +58,11 @@
 
 </section>
 
-<h2 class="text-center">Other</h2>
+<h2 class="mt-4">Other</h2>
 
 <section class="row mt-4">
   {{ range .Site.Taxonomies.tags.other }}
-  <div class="col-lg-4 col-md-6 mb-3 d-flex align-items-stretch">
+  <div class="col-lg-3 col-md-6 my-3 d-flex align-items-stretch">
     <div class="card">
       <a href="{{ .URL }}">
         <img class="card-img-top" src="/equipment/{{ .Params.photo }}" alt="Card image cap">


### PR DESCRIPTION
1. Changed all equipment markdown files to have tags relating to the section in which they belong 
2. Changed the equipment layout page making three sections: "woodworking", "metalworking" and "other". Under these names are the equipment names that correspond to them. 