### PR TITLE
Social Media Icons Fix

### DIFF
--- a/layouts/partials/social-media-icons.html
+++ b/layouts/partials/social-media-icons.html
@@ -2,7 +2,7 @@
   Follow Us
 </h4>
 <div>
-  <div style="display: flex" ;>
+  <div class="d-flex flex-wrap">
     <div style="font-size:40px; padding-right:5px;">
       <a href="https://twitter.com/rcmakes" target="blank">
         <i class="fab fa-twitter-square"></i>


### PR DESCRIPTION
1. Added flex-wrap feature to the social media icons to make them wrap on mobile so they don't overlap. 