### PR TITLE
Removed "alt text" error

### DIFF
--- a/content/equipment/3D-printer.md
+++ b/content/equipment/3D-printer.md
@@ -40,6 +40,3 @@ extruder (left or right)?
 10. Once the build starts, did the first layer stick and build correctly?
 
 11. Once the build is complete, do you know how to safely remove it from the build plate and leave the machine ready for the next build?
-
-![alt text](/equipment/heat-table-2.JPG "photo example")
-


### PR DESCRIPTION
1. Removed the Alt Text error from the bottom of the 3D Printer Equipment page